### PR TITLE
Publish needs write access - repository public npm publish should be to

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish --public
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISH }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISH }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdigit/github-actions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": " Provides supporting operations for github action builds.",
   "typings": "./dist/index.d.ts",
   "main": "./dist/index.js",


### PR DESCRIPTION
Two issues came up with the release publish
1. Current token is read only - need to switch it to the publish token
2. Repository is publish - npm package should be too.

Closes https://github.com/checkdigit/github-actions/issues/4