### PR TITLE
Bump allows v3 aws-sdk to 3.387.0

### DIFF
--- a/src/check-imports/packages-not-allowed.ts
+++ b/src/check-imports/packages-not-allowed.ts
@@ -17,10 +17,10 @@ const ESM_UNSUPPORTED_HIGHER =
   This is the list of packages that are not allowed to be imported.
  */
 const notAllowed: NotAllowed[] = [
-  ['@aws-sdk/client-*', '>3.193.0', UNSTABLE],
-  ['@aws-sdk/credential-provider-ini', '>3.193.0', UNSTABLE],
-  ['@aws-sdk/credential-provider-node', '>3.193.0', UNSTABLE],
-  ['@aws-sdk/smithy-client', '>3.193.0', UNSTABLE],
+  ['@aws-sdk/client-*', '>3.387.0', UNSTABLE],
+  ['@aws-sdk/credential-provider-ini', '>3.387.0', UNSTABLE],
+  ['@aws-sdk/credential-provider-node', '>3.387.0', UNSTABLE],
+  ['@aws-sdk/smithy-client', '>3.387.0', UNSTABLE],
   ['got', '>=12.0.0', ESM_UNSUPPORTED],
   ['get-port', '>=6.0.0', ESM_UNSUPPORTED],
   ['antlr4', '>4.9.3', ESM_UNSUPPORTED_HIGHER],

--- a/src/check-imports/packages-not-allowed.ts
+++ b/src/check-imports/packages-not-allowed.ts
@@ -5,9 +5,8 @@ export type Range = string;
 export type Reason = string;
 export type NotAllowed = [Name, Range, Reason];
 
-const UNSTABLE =
-  'Higher versions are unstable and break tests in Check Digit services. This can be removed from the Not Allowed list when stability improves.';
-
+// const UNSTABLE =
+//   'Higher versions are unstable and break tests in Check Digit services. This can be removed from the Not Allowed list when stability improves.';
 const ESM_UNSUPPORTED =
   'This version and higher use ESM which Check Digit does not support. This can be removed when Check Digit supports ESM.';
 const ESM_UNSUPPORTED_HIGHER =
@@ -17,10 +16,7 @@ const ESM_UNSUPPORTED_HIGHER =
   This is the list of packages that are not allowed to be imported.
  */
 const notAllowed: NotAllowed[] = [
-  ['@aws-sdk/client-*', '>3.387.0', UNSTABLE],
-  ['@aws-sdk/credential-provider-ini', '>3.387.0', UNSTABLE],
-  ['@aws-sdk/credential-provider-node', '>3.387.0', UNSTABLE],
-  ['@aws-sdk/smithy-client', '>3.387.0', UNSTABLE],
+  // ['@aws-sdk/client-*', '>3.387.0', UNSTABLE], // example of an unstable package
   ['got', '>=12.0.0', ESM_UNSUPPORTED],
   ['get-port', '>=6.0.0', ESM_UNSUPPORTED],
   ['antlr4', '>4.9.3', ESM_UNSUPPORTED_HIGHER],


### PR DESCRIPTION
Closes https://github.com/checkdigit/github-actions/issues/57
Required to support https://github.com/checkdigit/aws-nock/pull/459