### PR TITLE
Check Service and Resource name maximum length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@checkdigit/github-actions",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@checkdigit/github-actions",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkdigit/github-actions",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": " Provides supporting operations for github action builds.",
   "author": "Check Digit, LLC",
   "license": "MIT",

--- a/src/check-label/check-label-compare-match-semver.spec.ts
+++ b/src/check-label/check-label-compare-match-semver.spec.ts
@@ -6,9 +6,9 @@ import { describe, it } from '@jest/globals';
 
 import { validateVersion } from './check-label';
 
-const assertError = 'Version is incorrect based on Pull Request label';
+const assertError = /Version is incorrect based on Pull Request label/u; // expected error message when version is incorrect - assert adds additional information to error, so regex is used
 
-describe('compare and match semver', () => {
+describe.only('compare and match semver', () => {
   it('Test basic patch', async () => {
     assert.equal(validateVersion('1.0.1', '1.0.0', 'patch'), true);
 

--- a/src/check-label/check-label-compare-match-semver.spec.ts
+++ b/src/check-label/check-label-compare-match-semver.spec.ts
@@ -8,7 +8,7 @@ import { validateVersion } from './check-label';
 
 const assertError = /Version is incorrect based on Pull Request label/u; // expected error message when version is incorrect - assert adds additional information to error, so regex is used
 
-describe.only('compare and match semver', () => {
+describe('compare and match semver', () => {
   it('Test basic patch', async () => {
     assert.equal(validateVersion('1.0.1', '1.0.0', 'patch'), true);
 

--- a/src/publish-beta/validate-name-and-resource-length.spec.ts
+++ b/src/publish-beta/validate-name-and-resource-length.spec.ts
@@ -1,0 +1,148 @@
+// publish-beta/validate-name-and-resource-length.spec.ts
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from '@jest/globals';
+
+import { type PackageJSON, validateNameAndResourceLength } from './validate-name-and-resource-length';
+
+describe('Test name and resource length', () => {
+  it('No services property', async () => {
+    const packageJSON: PackageJSON = {};
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('No resources property', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('No aws resources property', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {},
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('Empty aws resources property', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {
+          aws: {},
+        },
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('Empty S3 resources property', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {
+          aws: {
+            s3: {},
+          },
+        },
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('Name all within valid length', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {
+          aws: {
+            s3: {
+              'valid-s3-name': {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'valid-s3-name',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('Service name too long', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestNameThatIsTooLong1',
+        resources: {
+          aws: {
+            s3: {
+              'valid-s3-name': {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'valid-s3-name',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await assert.rejects(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('Service name too long - except service', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'teampay-vendor-management',
+        resources: {
+          aws: {
+            s3: {
+              'valid-s3-name': {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'valid-s3-name',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('S3 bucket name too long', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {
+          aws: {
+            s3: {
+              bucket1: {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'valid name',
+                },
+              },
+              bucket2: {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'invalid-s3-bucket-length-01',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await assert.rejects(validateNameAndResourceLength(packageJSON));
+  });
+});

--- a/src/publish-beta/validate-name-and-resource-length.spec.ts
+++ b/src/publish-beta/validate-name-and-resource-length.spec.ts
@@ -99,6 +99,7 @@ describe('Test name and resource length', () => {
   });
 
   it('Service name too long - exempt service', async () => {
+    process.env['SERVICE_NAME_LENGTH_EXCEPTION'] = 'teampay-vendor-management';
     const packageJSON: PackageJSON = {
       service: {
         name: 'teampay-vendor-management',
@@ -147,6 +148,7 @@ describe('Test name and resource length', () => {
   });
 
   it('S3 bucket name too long - exempt bucket', async () => {
+    process.env['S3_BUCKET_NAME_LENGTH_EXCEPTIONS'] = 'ach.teampay.armor.inbound';
     const packageJSON: PackageJSON = {
       service: {
         name: 'TestName',
@@ -163,6 +165,40 @@ describe('Test name and resource length', () => {
                 Type: 'AWS::S3::Bucket',
                 Properties: {
                   BucketName: 'ach.teampay.armor.inbound',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('S3 bucket name too long - multiple exempt bucket', async () => {
+    process.env['S3_BUCKET_NAME_LENGTH_EXCEPTIONS'] = 'mastercard.armor.inbound,ach.teampay.armor.inbound';
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {
+          aws: {
+            s3: {
+              bucket1: {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'valid name',
+                },
+              },
+              'ach.teampay.armor.inbound': {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'ach.teampay.armor.inbound',
+                },
+              },
+              'mastercard.armor.inbound': {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'mastercard.armor.inbound',
                 },
               },
             },

--- a/src/publish-beta/validate-name-and-resource-length.spec.ts
+++ b/src/publish-beta/validate-name-and-resource-length.spec.ts
@@ -98,7 +98,7 @@ describe('Test name and resource length', () => {
     await assert.rejects(validateNameAndResourceLength(packageJSON));
   });
 
-  it('Service name too long - except service', async () => {
+  it('Service name too long - exempt service', async () => {
     const packageJSON: PackageJSON = {
       service: {
         name: 'teampay-vendor-management',
@@ -108,7 +108,7 @@ describe('Test name and resource length', () => {
               'valid-s3-name': {
                 Type: 'AWS::S3::Bucket',
                 Properties: {
-                  BucketName: 'valid-s3-name',
+                  BucketName: 'valid-s3-bucket-name',
                 },
               },
             },
@@ -135,7 +135,7 @@ describe('Test name and resource length', () => {
               bucket2: {
                 Type: 'AWS::S3::Bucket',
                 Properties: {
-                  BucketName: 'invalid-s3-bucket-length-01',
+                  BucketName: 'invalid-bucket-length',
                 },
               },
             },
@@ -144,5 +144,32 @@ describe('Test name and resource length', () => {
       },
     };
     await assert.rejects(validateNameAndResourceLength(packageJSON));
+  });
+
+  it('S3 bucket name too long - exempt bucket', async () => {
+    const packageJSON: PackageJSON = {
+      service: {
+        name: 'TestName',
+        resources: {
+          aws: {
+            s3: {
+              bucket1: {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'valid name',
+                },
+              },
+              'ach.teampay.armor.inbound': {
+                Type: 'AWS::S3::Bucket',
+                Properties: {
+                  BucketName: 'ach.teampay.armor.inbound',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    await assert.doesNotReject(validateNameAndResourceLength(packageJSON));
   });
 });

--- a/src/publish-beta/validate-name-and-resource-length.ts
+++ b/src/publish-beta/validate-name-and-resource-length.ts
@@ -37,8 +37,20 @@ const SERVICE_NAME_LENGTH_EXCEPTIONS = new Set([
   'teampay-vendor-management',
 ]); // list of services with names that are longer than limit
 
-const MAXIMUM_S3_BUCKET_NAME_LENGTH = 25;
-const S3_BUCKET_NAME_LENGTH_EXCEPTIONS = new Set(['']); // list of resources with names that are longer than limit
+const MAXIMUM_S3_BUCKET_NAME_LENGTH = 20;
+const S3_BUCKET_NAME_LENGTH_EXCEPTIONS = new Set([
+  'abcorp.vault.outbound',
+  'ach.inbound.tokenized',
+  'payment.vault.inbound',
+  'arroweye.vault.inbound',
+  'payment.vault.outbound',
+  'star.inbound.tokenized',
+  'arroweye.vault.outbound',
+  'choice.mc.scheme.report',
+  'mastercard.armor.inbound',
+  'ach.summary.armor.inbound',
+  'ach.teampay.armor.inbound',
+]); // list of resources with names that are longer than limit
 
 export async function readPackageJSON(rootProjectDirectory: string): Promise<PackageJSON> {
   const packageJSONPath = path.join(rootProjectDirectory, 'package.json');

--- a/src/publish-beta/validate-name-and-resource-length.ts
+++ b/src/publish-beta/validate-name-and-resource-length.ts
@@ -1,0 +1,98 @@
+// publish-beta/validate-name-and-resource-length.ts
+
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import debug from 'debug';
+
+const log = debug('github-actions:publish-beta:validate-names');
+
+interface S3Properties {
+  Type: 'AWS::S3::Bucket';
+  Properties: {
+    BucketName: string;
+  };
+}
+
+interface Resources {
+  aws?: {
+    s3?: Record<string, S3Properties>;
+  };
+}
+
+export interface PackageJSON {
+  service?: {
+    name: string;
+    resources?: Resources;
+  };
+}
+
+const MAXIMUM_SERVICE_NAME_LENGTH = 20;
+const SERVICE_NAME_LENGTH_EXCEPTIONS = new Set([
+  'current-certification',
+  'mngs-interchange-file',
+  'teampay-card-management',
+  'teampay-client-management',
+  'teampay-merchant-terminal',
+  'teampay-vendor-management',
+]); // list of services with names that are longer than limit
+
+const MAXIMUM_S3_BUCKET_NAME_LENGTH = 25;
+const S3_BUCKET_NAME_LENGTH_EXCEPTIONS = new Set(['']); // list of resources with names that are longer than limit
+
+export async function readPackageJSON(rootProjectDirectory: string): Promise<PackageJSON> {
+  const packageJSONPath = path.join(rootProjectDirectory, 'package.json');
+  const packageJSON = await readFile(packageJSONPath, 'utf8');
+  return JSON.parse(packageJSON) as PackageJSON;
+}
+
+async function validateS3BucketNames(input: Resources) {
+  if (input.aws?.s3 === undefined) {
+    log('package.json does not have a service.resources.aws.s3: {} property');
+    return;
+  }
+
+  const s3Resources = input.aws.s3;
+
+  const bucketNames = Object.values(s3Resources)
+    .map((resource) => resource.Properties.BucketName)
+    .filter((name) => !S3_BUCKET_NAME_LENGTH_EXCEPTIONS.has(name))
+    .filter((name) => name.length > MAXIMUM_S3_BUCKET_NAME_LENGTH);
+
+  if (bucketNames.length > 0) {
+    throw new Error(
+      `S3 bucket names are longer than ${MAXIMUM_S3_BUCKET_NAME_LENGTH} characters: ${JSON.stringify(bucketNames)}`,
+    );
+  }
+}
+
+export async function validateNameAndResourceLength(packageJSONWithResources: PackageJSON): Promise<void> {
+  if (!packageJSONWithResources.service) {
+    log('package.json does not have a service: {} property');
+    return;
+  }
+
+  const serviceName = packageJSONWithResources.service.name;
+
+  if (!SERVICE_NAME_LENGTH_EXCEPTIONS.has(serviceName) && serviceName.length > MAXIMUM_SERVICE_NAME_LENGTH) {
+    const message = `Service name ${serviceName} is longer than ${MAXIMUM_SERVICE_NAME_LENGTH} characters`;
+    log(message);
+    throw new Error(message);
+  }
+
+  if (!packageJSONWithResources.service.resources?.aws) {
+    log('package.json does not have a service.resources.aws: {} property');
+    return;
+  }
+  const resources = packageJSONWithResources.service.resources;
+  await validateS3BucketNames(resources);
+}
+
+export default async function (): Promise<void> {
+  log('Action start');
+
+  const packageJSONWithResources = await readPackageJSON(process.cwd());
+  await validateNameAndResourceLength(packageJSONWithResources);
+
+  log('Action end');
+}

--- a/src/validate-npm-package/validate-npm-package.spec.ts
+++ b/src/validate-npm-package/validate-npm-package.spec.ts
@@ -25,7 +25,10 @@ describe('validate-npm-package', () => {
     await verifyNpmPackage();
   }, 300_000);
 
-  it('bad npm package results in error', async () => {
+  // this test should reject but isn't now
+  // this did work historically
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('bad npm package results in error', async () => {
     actionsCoreSpy.mockImplementationOnce((name) => {
       if (name === 'betaPackage') {
         return '@checkdigit/approval@2.0.0-PR.196-b041';

--- a/src/validate-npm-package/validate-npm-package.spec.ts
+++ b/src/validate-npm-package/validate-npm-package.spec.ts
@@ -25,10 +25,11 @@ describe('validate-npm-package', () => {
     await verifyNpmPackage();
   }, 300_000);
 
-  // this test should reject but isn't now
-  // this did work historically
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('bad npm package results in error', async () => {
+  // Test uses a bad version of approval package
+  // and requires skipLibCheck: false in tsconfig.json
+  // we set it manually in validate npm package as
+  // checkdigit/typescript-config is various versions of this setting
+  it('bad npm package results in error', async () => {
     actionsCoreSpy.mockImplementationOnce((name) => {
       if (name === 'betaPackage') {
         return '@checkdigit/approval@2.0.0-PR.196-b041';

--- a/src/validate-npm-package/validate-npm-package.ts
+++ b/src/validate-npm-package/validate-npm-package.ts
@@ -63,6 +63,9 @@ async function generateProject(workFolder: string, packageJson: PackageJson): Pr
   // create tsconfig.json
   const tsconfigJson = {
     extends: '@checkdigit/typescript-config',
+    compilerOptions: {
+      skipLibCheck: false,
+    },
   };
   await fs.writeFile(`${workFolder}/tsconfig.json`, JSON.stringify(tsconfigJson, null, 2));
 }


### PR DESCRIPTION
Closes https://github.com/checkdigit/github-actions/issues/80
I went with some stricter limits on service names and s3 buckets with some exceptions for current cases we have. Open to alternative ideas. 

Additionally: Had to make unrelated changes to a couple of tests as what was in main was no longer passing tests - coverage test will have to be temporary removed for merging
* node change changed the output of assert and that caused some tests to fail on exact match - added regex to make this more reliable 
* Validate test failed as checkdigit/typescript-config has changed its setting for skipLibCheck a few times, hard set this value now